### PR TITLE
watch: Notify watches of connection loss

### DIFF
--- a/jetcd-core/src/test/java/com/coreos/jetcd/internal/impl/WatchUnitTest.java
+++ b/jetcd-core/src/test/java/com/coreos/jetcd/internal/impl/WatchUnitTest.java
@@ -70,7 +70,7 @@ public class WatchUnitTest {
   @Rule
   public Timeout timeout = Timeout.seconds(10);
   private Watch watchClient;
-  private ExecutorService executor = Executors.newFixedThreadPool(2);
+  private ExecutorService executor;
   private AtomicReference<StreamObserver<WatchResponse>> responseObserverRef;
   @Mock
   private StreamObserver<WatchRequest> requestStreamObserverMock;
@@ -283,6 +283,9 @@ public class WatchUnitTest {
                       Status.UNAVAILABLE.withDescription("Temporary connection issue").asRuntimeException());
       // resets mock call counter.
       Mockito.<StreamObserver>reset(this.requestStreamObserverMock);
+
+      // call listen to init reconnect
+      executor.submit(watcher::listen);
 
       // expects re-send WatchCreateRequest.
       verify(this.requestStreamObserverMock, timeout(1000).times(1))


### PR DESCRIPTION
Always send an EtcdException with Unavailable Status to active watchers
on connection loss. This fix guards against concurrency issues when creating
watches while the connection to etcd is being restored.